### PR TITLE
Fix code scanning alert no. 20: Incomplete string escaping or encoding

### DIFF
--- a/sqli/static/js/materialize.js
+++ b/sqli/static/js/materialize.js
@@ -1328,7 +1328,7 @@ Materialize.guid = function () {
  * @returns {string}
  */
 Materialize.escapeHash = function (hash) {
-  return hash.replace(/(:|\.|\[|\]|,|=)/g, "\\$1");
+  return hash.replace(/([:\\.\\[\\],=])/g, "\\$1");
 };
 
 Materialize.elementOrParentIsFixed = function (element) {


### PR DESCRIPTION
Fixes [https://github.com/KianuVela/dvpwa/security/code-scanning/20](https://github.com/KianuVela/dvpwa/security/code-scanning/20)

To fix the problem, we need to ensure that the backslash character is also escaped in the input string. This can be achieved by modifying the regular expression used in the `replace` method to include the backslash character. Additionally, we should use a well-tested sanitization library if possible, but for this specific fix, we will update the regular expression to handle the backslash character.

- Modify the regular expression in the `Materialize.escapeHash` function to include the backslash character.
- Ensure that the backslash character is escaped correctly by adding it to the list of characters in the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
